### PR TITLE
fix(db): change description column type to TEXT

### DIFF
--- a/src/main/java/sphynx/springfeedlens/domain/FeedItem.java
+++ b/src/main/java/sphynx/springfeedlens/domain/FeedItem.java
@@ -21,7 +21,7 @@ public class FeedItem {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String description;
 
     @Column(unique = true, nullable = false)


### PR DESCRIPTION
- Altered database schema to support unlimited text length

- Updated FeedItem entity with columnDefinition='TEXT'

- Resolves DataIntegrityViolationException for long content

Closes #2